### PR TITLE
fix: add permissions to Updatecli workflow for PR creation

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -19,6 +19,9 @@ on:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The Updatecli workflow was failing after merge with error:
```
ERROR: Action "default" failed: error getting remote pull request: 
Resource not accessible by integration
```

**Failed run**: https://github.com/gounthar/termux-jenkins-automation/actions/runs/18852987772

## Root Cause

The default `GITHUB_TOKEN` in GitHub Actions has read-only permissions. Updatecli needs write permissions to:
- Create branches with plugin updates
- Create pull requests
- Push commits

## Solution

Added explicit permissions to the workflow job:
```yaml
permissions:
  contents: write        # Push changes to branches
  pull-requests: write   # Create and manage PRs
```

## Testing

This PR will test the fix by triggering the Updatecli workflow with proper permissions.

## Impact

- Updatecli will now be able to create automated pull requests for plugin updates
- Weekly schedule will work correctly
- Manual workflow dispatch will work

## References

- GitHub Actions permissions: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
- Updatecli GitHub action: https://github.com/updatecli/updatecli-action

Fixes workflow run #18852987772